### PR TITLE
Improve status visuals and fix install dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
-<<<<<<< HEAD
-# YT_Downloader
-An app to Download any video on the Internet via URL.
-=======
-# LiquidGlass Downloader v2.2
+# LiquidGlass Downloader
 
-Patched status bar init and robust DB migration.
->>>>>>> 14e9f4e (first commit)
+LiquidGlass Downloader is a cross-platform application for downloading online videos.  It ships with a clean CustomTkinter GUI and a simple CLI so you can queue, track and manage your downloads with ease.
+
+## Features
+- Queue multiple URLs and monitor progress
+- Color‑coded status indicators with percentage progress
+- History export to CSV or JSON
+- Configurable themes, formats and concurrent downloads
+
+## Installation
+```bash
+pip install -e .
+```
+
+## Usage
+Launch the graphical interface:
+```bash
+liquidglass-gui
+```
+Run from the command line:
+```bash
+liquidglass-downloader <url> [<url> ...]
+```

--- a/liquidglass_downloader/ui/utils.py
+++ b/liquidglass_downloader/ui/utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from ..core.models import Status
+
+
+_STATUS_COLORS = {
+    Status.COMPLETED: ("#16a34a", "#16a34a"),  # green
+    Status.ERROR: ("#dc2626", "#dc2626"),      # red
+    Status.PAUSED: ("#eab308", "#eab308"),     # yellow
+    Status.CANCELED: ("#52525b", "#52525b"),   # gray
+    Status.DOWNLOADING: ("#3b82f6", "#3b82f6"),# blue
+    Status.QUEUED: ("#a1a1aa", "#a1a1aa"),     # default
+}
+
+
+def status_color(status: Status | str):
+    """Return a text color for a given download status."""
+    if isinstance(status, str):
+        try:
+            status = Status(status)
+        except ValueError:
+            return _STATUS_COLORS[Status.QUEUED]
+    return _STATUS_COLORS.get(status, _STATUS_COLORS[Status.QUEUED])
+

--- a/liquidglass_downloader/ui/views/history_view.py
+++ b/liquidglass_downloader/ui/views/history_view.py
@@ -3,7 +3,7 @@ import customtkinter as ctk
 from tkinter import filedialog
 import csv, json, os, subprocess, sys
 from ...core.db import DB_INSTANCE as DB
-from ...core.models import Status
+from ..utils import status_color
 
 def _open_in_folder(path: str):
     if not path: return
@@ -45,7 +45,11 @@ class HistoryView(ctk.CTkFrame):
         for r, item in enumerate(self._rows_data(), start=1):
             ctk.CTkLabel(self.scroll, text=str(item.id)).grid(row=r, column=0, padx=4, pady=2, sticky="w")
             ctk.CTkLabel(self.scroll, text=item.title or "-").grid(row=r, column=1, padx=4, pady=2, sticky="w")
-            ctk.CTkLabel(self.scroll, text=item.status).grid(row=r, column=2, padx=4, pady=2, sticky="w")
+            ctk.CTkLabel(
+                self.scroll,
+                text=item.status,
+                text_color=status_color(item.status),
+            ).grid(row=r, column=2, padx=4, pady=2, sticky="w")
             ctk.CTkButton(self.scroll, text="Show in Folder", command=lambda p=item.filepath: _open_in_folder(p)).grid(row=r, column=3, padx=4, pady=2, sticky="w")
 
     def export_json(self):

--- a/liquidglass_downloader/ui/views/queue_view.py
+++ b/liquidglass_downloader/ui/views/queue_view.py
@@ -4,10 +4,11 @@ from PIL import Image
 import os
 
 from ...core.db import DB_INSTANCE as DB
-from ...core.models import QueueItem, Status
+from ...core.models import QueueItem
 from ...core.config import CONFIG
 from ...core.downloader import DownloadManager
 from ..notifier import toast
+from ..utils import status_color
 
 def _fmt_bytes(n: int | None) -> str:
     if not n: return "-"
@@ -60,8 +61,11 @@ class QueueCard(ctk.CTkFrame):
         self.pbar.set(progress)
         self.pbar.grid(row=2, column=1, sticky="ew", padx=(0,6), pady=(0,8))
 
-        stats = f"{_fmt_bytes(got)} / {_fmt_bytes(total)}   •   {item.status}   •   {_fmt_speed(item.speed)}   •   ETA {_fmt_eta(item.eta)}"
-        self.stats_lbl = ctk.CTkLabel(self, text=stats)
+        stats = (
+            f"{_fmt_bytes(got)} / {_fmt_bytes(total)} "
+            f"({progress*100:.1f}%)   •   {item.status}   •   {_fmt_speed(item.speed)}   •   ETA {_fmt_eta(item.eta)}"
+        )
+        self.stats_lbl = ctk.CTkLabel(self, text=stats, text_color=status_color(item.status))
         self.stats_lbl.grid(row=3, column=1, sticky="w", padx=(0,6), pady=(0,8))
 
         btns = ctk.CTkFrame(self, fg_color="transparent")
@@ -80,8 +84,11 @@ class QueueCard(ctk.CTkFrame):
         got = item.downloaded_bytes or 0
         progress = (got / total) if total else 0
         self.pbar.set(progress)
-        stats = f"{_fmt_bytes(got)} / {_fmt_bytes(total)}   •   {item.status}   •   {_fmt_speed(item.speed)}   •   ETA {_fmt_eta(item.eta)}"
-        self.stats_lbl.configure(text=stats)
+        stats = (
+            f"{_fmt_bytes(got)} / {_fmt_bytes(total)} "
+            f"({progress*100:.1f}%)   •   {item.status}   •   {_fmt_speed(item.speed)}   •   ETA {_fmt_eta(item.eta)}"
+        )
+        self.stats_lbl.configure(text=stats, text_color=status_color(item.status))
 
 class QueueView(ctk.CTkFrame):
     def __init__(self, master, dm: DownloadManager):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ license = {text = "MIT"}
 keywords = ["youtube", "downloader", "yt-dlp", "gui", "customtkinter"]
 
 dependencies = [
-  "yt-dlp>=2025.1.1",
+  # use a released version of yt-dlp so the project installs cleanly
+  "yt-dlp>=2024.3",
   "pydantic>=2.5",
   "platformdirs>=4.2",
   "customtkinter>=5.2",


### PR DESCRIPTION
## Summary
- replace unreleased yt-dlp requirement with available version
- add utility for status colors and show progress percentages in queue
- color-code history entries and update README

## Testing
- `pip install -e .[dev]`
- `pytest`
- `python -m liquidglass_downloader.cli -h`
- `ruff check .` *(fails: multiple existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aadf5050ec8322aac31f58402d2181